### PR TITLE
[FIX][T13975] Custom frequency time option creates extra activities

### DIFF
--- a/nh_ews/ews.py
+++ b/nh_ews/ews.py
@@ -1059,16 +1059,6 @@ class nh_clinical_patient_observation_ews(orm.Model):
             cr, uid, d, ['name'],
             context=context)['name']] for d in device_ids]
 
-        # Custom frequency times
-        custom_frequency_time_pool = self.pool['nh.clinical.patient.custom_frequency_time']
-        custom_frequency_options_pool = self.pool['nh.clinical.custom_frequency_options']
-        custom_frequency_options_id = custom_frequency_time_pool.get_last(cr, uid, patient_id, context=context)
-        if not custom_frequency_options_id:
-            custom_frequency_options_id = False
-        else:
-            custom_frequency_options = custom_frequency_options_pool.browse(cr, uid, custom_frequency_options_id, context=context)
-            custom_frequency_time = custom_frequency_options.name
-
         for field in fd:
             if field['name'] == 'indirect_oxymetry_spo2' and o2target:
                 field['secondary_label'] = 'Target: {0}'.format(o2target)

--- a/nh_ews/parameters.py
+++ b/nh_ews/parameters.py
@@ -124,31 +124,8 @@ class nh_clinical_patient_o2target(orm.Model):
 class NHClinicalPatientCustomFrequencyTime(orm.Model):
 
     _name = 'nh.clinical.patient.custom_frequency_time'
-    _inherit = ['nh.activity.data']
     _rec_name = 'options_id'
     _columns = {
         'options_id': fields.many2one('nh.clinical.custom_frequency_options', 'Custom frequency options'),
         'patient_id': fields.many2one('nh.clinical.patient', 'Patient', required=True)
     }
-
-    def get_last(self, cr, uid, patient_id, datetime=False, context=None):
-        if not datetime:
-            datetime = dt.now().strftime(dtf)
-        domain = [
-            ['patient_id', '=', patient_id],
-            ['data_model', '=', 'nh.clinical.patient.custom_frequency_time'],
-            ['state', '=', 'completed'],
-            ['parent_id.state', '=', 'started'],
-            ['date_terminated', '<=', datetime]
-        ]
-        activity_pool = self.pool['nh.activity']
-        custom_frequency_time_ids = activity_pool.search(
-            cr, uid, domain, order='date_terminated desc, sequence desc',
-            context=context
-        )
-        if not custom_frequency_time_ids:
-            return False
-        activity = activity_pool.browse(
-            cr, uid, custom_frequency_time_ids[0], context=context
-        )
-        return activity.data_ref.options_id.id if activity.data_ref.options_id else False

--- a/nh_observations/parameters.py
+++ b/nh_observations/parameters.py
@@ -23,7 +23,6 @@ _logger = logging.getLogger(__name__)
 
 class NHClinicalPatientUseCustomFrequency(orm.Model):
     _name = 'nh.clinical.patient.use_custom_frequency'
-    _inherit = ['nh.activity.data']
     _columns = {
         'status': fields.boolean('Use custom frequency'),
         'patient_id': fields.many2one('nh.clinical.patient', 'Patient', required=True),


### PR DESCRIPTION
Refactor of the sql views and associated models so that the nonsensical 'activity' that was being created when enabling custom frequency time no longer exists. Updated ews1 sql view as that is used for the tasks list (ews0 is used for patients list and wardboard).