### PR TITLE
[FIX] uncaught exceptions will still cause the backup procedure to fail

### DIFF
--- a/nh_eobs_backup/backup_procedure.py
+++ b/nh_eobs_backup/backup_procedure.py
@@ -285,7 +285,10 @@ class NHClinicalObservationReportPrinting(orm.Model):
                         self.pool['nh.clinical.spell'].write(
                             cr, uid, spell, {'report_printed': True})
                 else:
-                    _logger.warning('Cannot save PDF report, trust id missing, Spell Id: {0}'.format(spell))
+                    _logger.warning('Cannot save PDF report for Spell: {0}, other_identifier missing'.format(spell))
             except except_orm:
+                pass
+            except:
+                _logger.error('Error creating PDF for Spell: {0}'.format(spell))
                 pass
         return True


### PR DESCRIPTION
This is a temporary fix to get past the issue of the whole backup procedure failing. This file is to be cleaned up to remove the now obsolete lines and a more verbose log when the catch all exception happens