### PR TITLE
[FIX][I3] Have to click eObs twice to see the left hand menu list

### DIFF
--- a/nh_eobs/static/src/js/nh_eobs_v0_0_1.js
+++ b/nh_eobs/static/src/js/nh_eobs_v0_0_1.js
@@ -860,7 +860,7 @@ openerp.nh_eobs = function (instance) {
                     if (kiosk._timer) {
                         clearInterval(kiosk._timer);
                     }
-                    $(".oe_leftbar").addClass("nh_eobs_show");
+                    $(".oe_leftbar").removeClass('nh_eobs_hide').addClass('nh_eobs_show').show();
                     $(".oe_searchview").show();
                 }
             })


### PR DESCRIPTION
When the current page is not Kiosk, explicitly change the show/hide class and show the left column.