### PR TITLE
[FIX][T15384] NEWS Analysis creates trace error when viewing date field

### DIFF
--- a/nh_eobs_analysis/news.py
+++ b/nh_eobs_analysis/news.py
@@ -11,8 +11,8 @@ class nh_eobs_news_report(osv.Model):
     _columns = {
         'user_id': fields.many2one('res.users', 'Taken By', readonly=True),
         'date_scheduled': fields.datetime('Date Scheduled', readonly=True),
-        'date_terminated': fields.datetime('Date Taken', readonly=True),
-        'effective_date_terminated': fields.datetime('Date Taken', readonly=True),
+        'date_terminated': fields.datetime('Submitted Date', readonly=True),
+        'effective_date_terminated': fields.datetime('Effective Date Taken', readonly=True),
         'ward_id': fields.many2one('nh.clinical.location', 'Ward',
                                    readonly=True),
         'location_str': fields.char('Location', readonly=True),
@@ -51,6 +51,7 @@ class nh_eobs_news_report(osv.Model):
             end as obs_type,
             a.date_scheduled as date_scheduled,
             a.effective_date_terminated as effective_date_terminated,
+            a.date_terminated as date_terminated,
             a.location_id as location_id,
             case
                 when char_length(loc.name) = 5 then
@@ -155,6 +156,7 @@ class nh_eobs_news_report(osv.Model):
                 a.terminate_uid,
                 obs_type,
                 a.date_scheduled,
+                a.date_terminated,
                 a.effective_date_terminated,
                 a.location_id,
                 location_str,


### PR DESCRIPTION
Because effective_date_terminated was added and declared as an odoo field and the SQL view had references to date_terminated changed to effective_date_terminated (but date_terminated was not removed), the pivot view was trying to load date_terminated when is wasn't available on the SQL View. This commit adds both fields and changes the field string names so that it is clearer to the user of what they are selecting.