### PR TITLE
046

### DIFF
--- a/nh_activity/activity.py
+++ b/nh_activity/activity.py
@@ -125,7 +125,8 @@ class nh_activity(orm.Model):
             'Termination Time', help="Completed, Aborted, Expired, Cancelled",
             readonly=True),
         'effective_date_terminated': fields.datetime(
-            'Effective Termination Time', help="Completed, Aborted, Expired, Cancelled",
+            'Effective Date (ONLY CHANGE EFFECTIVE TIME IF NEEDED - Observation times can only be back-dated by 8 hours)',
+            help="Completed, Aborted, Expired, Cancelled",
             readonly=True),
         # dates limits
         'date_deadline': fields.datetime('Deadline Time', readonly=True),

--- a/nh_clinical/api.py
+++ b/nh_clinical/api.py
@@ -350,8 +350,5 @@ class nh_clinical_api(orm.AbstractModel):
         activity_ids = activity_pool.search(cr, uid, domain, context=context)
         if not activity_ids:
             return False
-        user_id = activity_pool.read(
-            cr, uid, activity_id, ['user_id'], context=context)['user_id']
-        if user_id and user_id[0] != uid:
-            return False
+
         return True

--- a/nh_eobs_mobile/controllers/main.py
+++ b/nh_eobs_mobile/controllers/main.py
@@ -715,6 +715,8 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
                     break
                 except ValueError:
                     pass
+                except KeyError:
+                    pass
 
         cr, uid, context = request.cr, request.session.uid, request.context
         obj_nh_activity = request.registry['nh.activity']


### PR DESCRIPTION
As part of the removal of shift allocation a task can now be completed by any user (not just those assigned to the ward). Disables the uid check against an activity completion.

Updates the label for the effective_date field for all observation types on the mobile form.