### PR TITLE
O2093 & O2087

### DIFF
--- a/nh_eobs_mobile/controllers/main.py
+++ b/nh_eobs_mobile/controllers/main.py
@@ -685,6 +685,17 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
             effective_date = record.activity_id.creator_id.effective_date_terminated
             vals.update({'effective_date_terminated': effective_date})
 
+        def _cancel_next_blood_glucose():
+            nh_activity_obj = request.registry['nh.activity']
+            task = obj_model.browse(cr, uid, int(val), context=context)
+            if task.observation == 'nh.clinical.patient.observation.blood_glucose':
+                next_blood_glucose_activity_id = nh_activity_obj.search(cr, uid, [
+                    ('state', '=', 'scheduled'),
+                    ('data_model', '=', 'nh.clinical.patient.observation.blood_glucose'),
+                    ('patient_id', '=', task.patient_id.id)
+                ], context=context)
+                nh_activity_obj.cancel(cr, uid, next_blood_glucose_activity_id, context=context)
+
         def _check_if_custom_frequency():
 
             def _find_next_ews_obs(patient_id):
@@ -732,6 +743,7 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
                     if kwargs[kwargs[key]].encode("utf-8") == 'no':
                         reason_id = int(kwargs[kwargs[key]+'_cancel'])
                         obj_model.write(cr, uid, int(val), {"reason": reason_id}, context=context)
+                        _cancel_next_blood_glucose()
                     record_id = int(kwargs[key])
                     record = obj_model.browse(cr, uid, record_id, context=context)
 

--- a/nh_eobs_mobile/views/template.xml
+++ b/nh_eobs_mobile/views/template.xml
@@ -113,7 +113,7 @@
                     <ul class="tasklist">
                         <t t-if="notifications">
                             <t t-foreach="notifications" t-as="notification">
-                                <li>
+                                <li style="display: none;">
                                     <a href="#" class="share_invite block" t-att-data-invite-id="notification['id']">
                                         <div class="task-meta" t-att-data-invite-id="notification['id']">
                                             <div class="task-right" t-att-data-invite-id="notification['id']">
@@ -135,7 +135,7 @@
                             </t>
                         </t>
                         <t t-foreach="items" t-as="item">
-                            <li>
+                            <li style="display: none;">
                                 <a t-att-href="item['url']" t-att-class="item['color']+' block'">
                                     <div class="task-meta">
                                         <div class="task-right">
@@ -343,13 +343,22 @@
                                             <input type="hidden" t-att-name="task['task_model']"
                                                    t-att-value="task['task_id']"/>
                                             <input type="radio" t-att-name="task['task_id']"
-                                                   t-att-id="task['task_id']" value="yes" onclick="yesnoCheck(this)" required="1"/>
-                                            <label t-att-for="task['task_id']">
+                                                   t-att-id="task['task_id']" value="yes" onclick="yesnoCheck(this)"
+                                                   t-att-checked="'checked' if task['task_model']=='nh.clinical.notification.hca' else ''"
+                                                   t-att-style="'display: none;' if task['task_model']=='nh.clinical.notification.hca' else ''"
+                                            />
+                                            <label t-att-for="task['task_id']"
+                                                   t-att-style="'display: none;' if task['task_model']=='nh.clinical.notification.hca' else ''"
+                                            >
                                                 Yes
                                             </label>
                                             <input type="radio" t-att-name="task['task_id']"
-                                                   t-att-id="task['task_id']" value="no" onclick="yesnoCheck(this)"/>
-                                            <label t-att-for="task['task_id']">
+                                                   t-att-id="task['task_id']" value="no" onclick="yesnoCheck(this)"
+                                                   t-att-style="'display: none;' if task['task_model']=='nh.clinical.notification.hca' else ''"
+                                            />
+                                            <label t-att-for="task['task_id']"
+                                                   t-att-style="'display: none;' if task['task_model']=='nh.clinical.notification.hca' else ''"
+                                            >
                                                 No
                                             </label>
                                                 </div>


### PR DESCRIPTION
* When a blood glucose task is submitted and escalation task of 'review frequency' is generated. If 'No' is selected for this review frequency task, then a 'next' blood glucose observation task should not exist.

* A clinical support worker will only have 1 escalation task after performing a NEWS observation. Instead of giving them the option of yes/no of completing the task, the option yes is now always selected and then the options are hidden from the form. This simulates it being a 'notification', but still preserves the audit trail of the task being completed.
