### PR TITLE
[FIX] Time to next Blood Glucose not displayed anywhere

### DIFF
--- a/nh_blood_glucose/views/wardboard_view.xml
+++ b/nh_blood_glucose/views/wardboard_view.xml
@@ -19,6 +19,10 @@
             <field name="model">nh.clinical.wardboard</field>
             <field name="inherit_id" ref="nh_eobs.view_wardboard_form"/>
             <field name="arch" type="xml">
+                <field name="next_diff" position="after">
+                    <field name="blood_glucose_frequency"/>
+                    <field name="next_blood_glucose_diff"/>
+                </field>
                 <xpath expr="/form/header" position="inside">
                     <button name="wardboard_blood_glucose_chart" string="Blood Glucose Chart" type="object" groups="base.group_user" attrs="{'invisible':[['patient_id','=',False]]}"/>
                 </xpath>

--- a/nh_eobs/observation_extension.py
+++ b/nh_eobs/observation_extension.py
@@ -7,7 +7,7 @@ from openerp.addons.nh_eobs.helpers import refresh_materialized_views
 class nh_clinical_patient_observation_ews(orm.Model):
     _inherit = 'nh.clinical.patient.observation.ews'
 
-    @refresh_materialized_views('ews0', 'ews1', 'ews2')
+    @refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_ews, self).complete(
@@ -27,7 +27,7 @@ class nh_clinical_patient_o2target(orm.Model):
 class nh_clinical_notification_frequency(orm.Model):
     _inherit = 'nh.clinical.notification.frequency'
 
-    @refresh_materialized_views('ews0', 'ews1', 'ews2')
+    @refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_notification_frequency, self).complete(

--- a/nh_eobs/sql_statements.py
+++ b/nh_eobs/sql_statements.py
@@ -89,11 +89,30 @@ class NHEobsSQL(orm.AbstractModel):
                 ews0.date_scheduled)), 'HH24:MI') || ' hours'
             ELSE to_char((INTERVAL '0s'), 'HH24:MI')
         END AS next_diff,
+        CASE
+            WHEN bg0.date_scheduled IS NOT NULL THEN
+              CASE WHEN extract(days FROM (greatest(now() AT TIME ZONE 'UTC',
+                bg0.date_scheduled) - least(now() AT TIME ZONE 'UTC',
+                bg0.date_scheduled))) > 0
+                THEN extract(days FROM (greatest(now() AT TIME ZONE 'UTC',
+                    bg0.date_scheduled) - least(now() AT TIME ZONE 'UTC',
+                    bg0.date_scheduled))) || ' day(s) '
+                ELSE '' END ||
+              to_char(justify_hours(greatest(now() AT TIME ZONE 'UTC',
+                bg0.date_scheduled) - least(now() AT TIME ZONE 'UTC',
+                bg0.date_scheduled)), 'HH24:MI') || ' hours'
+            ELSE to_char((INTERVAL '0s'), 'HH24:MI')
+        END AS next_blood_glucose_diff,
         CASE ews0.frequency < 60
             WHEN true THEN ews0.frequency || ' min(s)'
             ELSE ews0.frequency/60 || ' hour(s) ' || ews0.frequency -
                 ews0.frequency/60*60 || ' min(s)'
         END AS frequency,
+        CASE bg0.frequency < 60
+            WHEN true THEN bg0.frequency || ' min(s)'
+            ELSE bg0.frequency/60 || ' hour(s) ' || bg0.frequency -
+                bg0.frequency/60*60 || ' min(s)'
+        END AS blood_glucose_frequency,
         ews0.date_scheduled,
         CASE WHEN ews1.id IS NULL THEN 'none' ELSE ews1.score::text END
             AS ews_score_string,
@@ -145,6 +164,7 @@ class NHEobsSQL(orm.AbstractModel):
     LEFT JOIN ews1 ON spell.id = ews1.spell_id
     LEFT JOIN ews2 ON spell.id = ews2.spell_id
     LEFT JOIN ews0 ON spell.id = ews0.spell_id
+    LEFT JOIN bg0 ON spell.id = bg0.spell_id
     LEFT JOIN ward_locations wlocation ON wlocation.id = location.id
     LEFT JOIN consulting_doctors ON consulting_doctors.spell_id = spell.id
     LEFT JOIN pbp pbp ON pbp.spell_id = spell.id
@@ -403,6 +423,23 @@ class NHEobsSQL(orm.AbstractModel):
                     ews0.date_scheduled)), 'HH24:MI') || ' hours'
                 else to_char((interval '0s'), 'HH24:MI') || ' hours'
             end as next_ews_time,
+            case
+                when bg0.date_scheduled is not null then
+                  case when greatest(now() at time zone 'UTC',
+                    bg0.date_scheduled) != bg0.date_scheduled
+                    then 'overdue: ' else '' end ||
+                  case when extract(days from (greatest(now() at time zone
+                    'UTC', bg0.date_scheduled) - least(now() at time zone
+                    'UTC', bg0.date_scheduled))) > 0
+                    then extract(days from (greatest(now() at time zone 'UTC',
+                      bg0.date_scheduled) - least(now() at time zone 'UTC',
+                      bg0.date_scheduled))) || ' day(s) '
+                    else '' end ||
+                  to_char(justify_hours(greatest(now() at time zone 'UTC',
+                    bg0.date_scheduled) - least(now() at time zone 'UTC',
+                    bg0.date_scheduled)), 'HH24:MI') || ' hours'
+                else to_char((interval '0s'), 'HH24:MI') || ' hours'
+            end as next_bg_time,
             location.name as location,
             location_parent.name as parent_location,
             case
@@ -437,6 +474,7 @@ class NHEobsSQL(orm.AbstractModel):
         left join ews1 on ews1.spell_activity_id = activity.id
         left join ews2 on ews2.spell_activity_id = activity.id
         left join ews0 on ews0.spell_activity_id = activity.id
+        left join bg0 on bg0.spell_activity_id = activity.id
         where activity.state = 'started' and activity.data_model =
           'nh.clinical.spell' and activity.id in ({spell_ids})
         order by location

--- a/nh_eobs/views/wardboard_view.xml
+++ b/nh_eobs/views/wardboard_view.xml
@@ -439,12 +439,20 @@
                                             n/a
                                         </t>
                                     </div>
-                                    <li>Time to next observation:
+                                    <li>Time to next NEWS observation:
                                         <t t-if="record.next_diff.raw_value &amp;&amp; record.next_diff.raw_value.indexOf('overdue: ') &gt; -1">
                                             <strong><field name="next_diff"/></strong>
                                         </t>
                                         <t t-if="record.next_diff.raw_value &amp;&amp; record.next_diff.raw_value.indexOf('overdue: ') &lt; 0">
                                             <field name="next_diff"/>
+                                        </t>
+                                    </li>
+                                    <li>Time to next Blood Glucose observation:
+                                        <t t-if="record.next_blood_glucose_diff.raw_value &amp;&amp; record.next_blood_glucose_diff.raw_value.indexOf('overdue: ') &gt; -1">
+                                            <strong><field name="next_blood_glucose_diff"/></strong>
+                                        </t>
+                                        <t t-if="record.next_blood_glucose_diff.raw_value &amp;&amp; record.next_blood_glucose_diff.raw_value.indexOf('overdue: ') &lt; 0">
+                                            <field name="next_blood_glucose_diff"/>
                                         </t>
                                     </li>
                                     <t t-if="record.hospital_number.raw_value != ''">
@@ -506,7 +514,8 @@
                                             n/a
                                         </t>
                                     </div>
-                                    <li>Time to next observation:<field name="next_diff"/></li>
+                                    <li>Time to next NEWS observation:<field name="next_diff"/></li>
+                                    <li>Time to next Blood Glucose observation:<field name="next_blood_glucose_diff"/></li>
                                     <t t-if="record.hospital_number.raw_value != ''">
                                         <div>Hospital Number: <field name="hospital_number"/></div>
                                     </t>

--- a/nh_eobs_mental_health/models/nh_clinical_wardboard.py
+++ b/nh_eobs_mental_health/models/nh_clinical_wardboard.py
@@ -121,7 +121,7 @@ class NHClinicalWardboard(orm.Model):
             'view_id': view_id
         }
 
-    @helpers.v8_refresh_materialized_views('ews0', 'ews1', 'ews2')
+    @helpers.v8_refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
     @api.multi
     def start_obs_stop(self, reasons, spell_id, spell_activity_id):
         """
@@ -165,7 +165,7 @@ class NHClinicalWardboard(orm.Model):
         obs_stop = activity.data_ref
         obs_stop.start(activity_id)
 
-    @helpers.v8_refresh_materialized_views('ews0', 'ews1', 'ews2')
+    @helpers.v8_refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
     @api.multi
     def end_obs_stop(self, cancellation=False):
         """
@@ -297,6 +297,7 @@ class NHClinicalWardboard(orm.Model):
                     ],
                     context=context)
                 rec['rapid_tranq'] = spell.get('rapid_tranq')
+                rec['next_blood_glucose_diff'] = rec['next_blood_glucose_diff'] if rec['next_blood_glucose_diff'] != '00:00' else ''
                 if spell.get('obs_stop'):
                     obs_stop_model = self.pool['nh.clinical.pme.obs_stop']
                     obs_stops = obs_stop_model.search(cr, user, [
@@ -308,9 +309,11 @@ class NHClinicalWardboard(orm.Model):
                             cr, user, obs_stop, ['reason'], context=context)
                         rec['frequency'] = reason.get('reason', [0, False])[1]
                     rec['next_diff'] = 'Observations Stopped'
+                    rec['next_blood_glucose_diff'] = 'Observations Stopped'
                 elif spell.get('refusing_obs'):
                     rec['frequency'] = 'Refused - {0}'.format(rec['frequency'])
                     rec['next_diff'] = 'Refused - {0}'.format(rec['next_diff'])
+                    rec['next_blood_glucose_diff'] = 'Refused - {0}'.format(rec['next_blood_glucose_diff'])
         if was_single_record:
             return res[0]
         return res

--- a/nh_eobs_mental_health/models/nh_eobs_mobile_main.py
+++ b/nh_eobs_mental_health/models/nh_eobs_mobile_main.py
@@ -78,8 +78,11 @@ class NHEobsMobileMain(orm.AbstractModel):
                 patient['ews_trend'])
             if status_map.get(patient.get('id'), {}).get('obs_stop'):
                 patient['deadline_time'] = 'Observations Stopped'
+                patient['bg_deadline_time'] = 'Observations Stopped'
             else:
                 patient['deadline_time'] = patient['next_ews_time']
+                patient['bg_deadline_time'] = patient['next_bg_time'] \
+                    if patient['next_bg_time'] else ''
             patient['rapid_tranq'] = status_map.get(
                 patient.get('id'), {}).get('rapid_tranq', False)
             patient['summary'] = patient.get('summary', False)

--- a/nh_eobs_mobile/controllers/main.py
+++ b/nh_eobs_mobile/controllers/main.py
@@ -497,6 +497,8 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
             patient['trend_icon'] = 'icon-{0}-arrow'.format(
                 patient['ews_trend'])
             patient['deadline_time'] = patient['next_ews_time']
+            patient['bg_deadline_time'] = patient['next_bg_time'] \
+                if patient['next_bg_time'] else ''
             patient['summary'] = patient.get('summary', False)
             if patient.get('followers'):
                 followers = patient['followers']
@@ -782,7 +784,8 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
                             ])
                             if len(obs_id) == 1:
                                 creator_data_model.write(cr, uid, obs_id, vals, context=context)
-                                cr.execute('refresh materialized view ews0;\n')
+                                cr.execute('refresh materialized view ews0;\n'
+                                           'refresh materialized view bg0;')
                         obj_model.write(cr, uid, record_id, vals)
 
         _check_if_custom_frequency()

--- a/nh_eobs_mobile/views/template.xml
+++ b/nh_eobs_mobile/views/template.xml
@@ -140,7 +140,7 @@
                                     <div class="task-meta">
                                         <div class="task-right">
                                             <p class="aside">
-                                                <t t-esc="item['deadline_time']"/>
+                                                NEWS: <t t-esc="item['deadline_time']"/>
                                             </p>
                                             <t t-if="'follower_ids' in item and user_id in item['follower_ids']">
                                                 <p class="aside">Claim</p>


### PR DESCRIPTION
Since adding the facility of having scheduled blood glucose observations, it is now required that 'Time to next obs' needs to be displayed along side any time to next NEWS obs. This commit makes the required changes to SQL views to store the data in the correct places, and view changes to render accordingly.