### PR TITLE
Fix KeyError when loading 'Patients by Ward'

### DIFF
--- a/nh_eobs_mental_health/models/nh_clinical_wardboard.py
+++ b/nh_eobs_mental_health/models/nh_clinical_wardboard.py
@@ -298,10 +298,10 @@ class NHClinicalWardboard(orm.Model):
                     context=context)
                 rec['rapid_tranq'] = spell.get('rapid_tranq')
 
-                if rec.get('next_blood_glucose_diff'):
-                    rec['next_blood_glucose_diff'] = rec['next_blood_glucose_diff'] \
-                        if rec['next_blood_glucose_diff'] != '00:00' else ''
-                else:
+                if rec.get('next_blood_glucose_diff') \
+                        and rec.get('next_blood_glucose_diff') == '00:00':
+                    rec['next_blood_glucose_diff'] = ''
+                elif not rec.get('next_blood_glucose_diff'):
                     rec['next_blood_glucose_diff'] = ''
 
                 if spell.get('obs_stop'):

--- a/nh_eobs_mental_health/models/nh_clinical_wardboard.py
+++ b/nh_eobs_mental_health/models/nh_clinical_wardboard.py
@@ -297,7 +297,13 @@ class NHClinicalWardboard(orm.Model):
                     ],
                     context=context)
                 rec['rapid_tranq'] = spell.get('rapid_tranq')
-                rec['next_blood_glucose_diff'] = rec['next_blood_glucose_diff'] if rec['next_blood_glucose_diff'] != '00:00' else ''
+
+                if rec.get('next_blood_glucose_diff'):
+                    rec['next_blood_glucose_diff'] = rec['next_blood_glucose_diff'] \
+                        if rec['next_blood_glucose_diff'] != '00:00' else ''
+                else:
+                    rec['next_blood_glucose_diff'] = ''
+
                 if spell.get('obs_stop'):
                     obs_stop_model = self.pool['nh.clinical.pme.obs_stop']
                     obs_stops = obs_stop_model.search(cr, user, [


### PR DESCRIPTION
[I57] Patients by Ward page returns a stack trace KeyError related to the next blood glucose diff value. This fix checks to see if the key exists before formatting it and adding it to the 'rec' dictionary.