### PR TITLE
Fix 'overdue: ' missing from 'Time to next Blood Glucose'

### DIFF
--- a/nh_eobs/sql_statements.py
+++ b/nh_eobs/sql_statements.py
@@ -89,6 +89,7 @@ class NHEobsSQL(orm.AbstractModel):
                 ews0.date_scheduled)), 'HH24:MI') || ' hours'
             ELSE to_char((INTERVAL '0s'), 'HH24:MI')
         END AS next_diff,
+        bg0.next_diff_polarity ||
         CASE
             WHEN bg0.date_scheduled IS NOT NULL THEN
               CASE WHEN extract(days FROM (greatest(now() AT TIME ZONE 'UTC',


### PR DESCRIPTION
[I60] Time to next Blood Glucose does not have the 'overdue: ' prefix (if it is overdue) on the desktop view (kanban tiles and patient summary). They are both derived from the same value in the nh.clinical.wardboard SQL view.