### PR TITLE
Materialised view bg0 should be refreshed after BG obs are stopped

### DIFF
--- a/nh_eobs_mobile/controllers/main.py
+++ b/nh_eobs_mobile/controllers/main.py
@@ -699,6 +699,7 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
                         ('patient_id', '=', task.patient_id.id)
                     ], context=context)
                     nh_activity_obj.cancel(cr, uid, next_blood_glucose_activity_id, context=context)
+                    request.cr.execute("""refresh materialized view bg0;""")
             except AttributeError:
                 # task.observation does not exist
                 # The task is not an observation (probably an escalation task)


### PR DESCRIPTION
[I61] If no is selected for review frequency of a scheduled blood glucose observation then the next scheduled observation is correctly cancelled, but the materialised view that is used for data in nh.clinical.wardboard does not get updated. This commit calls cr.execute to refresh the view as part of stopping/cancelling the scheduled blood glucose observation.