### PR TITLE
Fixes field converter key error during Neurological observation

### DIFF
--- a/nh_eobs_api/controllers/route_api.py
+++ b/nh_eobs_api/controllers/route_api.py
@@ -403,6 +403,10 @@ class NH_API(openerp.addons.web.controllers.main.Home):
                     'respiration_rate'
                 ]:
                     del data[key]
+
+        # iPad submits a key as an empty string which converter doesn't like
+        data = {k: v for k, v in data.items() if k}
+
         converted_data = converter(data, _logger.debug)
 
         score_dict = api_pool.get_activity_score(


### PR DESCRIPTION
[I63] When submitting Neurological obs on an iPad, the iPad sends an additional field value with no key. This fix removes any keys that are None, empty string, etc before running the data converter.