### PR TITLE
Fixes issue of invalid SQL syntax if there is only one id in the tuple

### DIFF
--- a/nh_eobs_mobile/controllers/main.py
+++ b/nh_eobs_mobile/controllers/main.py
@@ -908,7 +908,9 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
                     SELECT w.name
                     FROM nh_clinical_wardboard AS wb
                     LEFT JOIN nh_clinical_location AS w ON wb.ward_id=w.id
-                    WHERE wb.id IN {}""".format(tuple(wardboard_records.ids))
+                    WHERE wb.id IN ({})""".format(
+                    ','.join(str(r) for r in wardboard_records.ids)
+                )
                 request.env.cr.execute(locations_name_query)
                 ward_names = request.env.cr.fetchall()
                 locations = set(ward_names)


### PR DESCRIPTION
Using tuple() as part of the string formatting produces a trailing comma when there is only one id. This changes tuple() to join() to produce valid SQL syntax.