### PR TITLE
Speeds up the submission of a blood glucose observation

### DIFF
--- a/nh_blood_glucose/models/nh_clinical_patient_observation_blood_glucose.py
+++ b/nh_blood_glucose/models/nh_clinical_patient_observation_blood_glucose.py
@@ -2,7 +2,7 @@
 from copy import deepcopy
 from openerp import models, api
 from openerp.osv import fields
-from openerp.addons.nh_eobs.helpers import refresh_materialized_views
+# from openerp.addons.nh_eobs.helpers import refresh_materialized_views
 from openerp.addons.nh_odoo_fixes import validate
 
 
@@ -75,7 +75,7 @@ class NHClinicalPatientObservationBloodGlucose(models.Model):
             .get_formatted_obs(replace_zeros=replace_zeros,
                                convert_datetimes_to_client_timezone=convert)
 
-    @refresh_materialized_views('param')
+    # @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             NHClinicalPatientObservationBloodGlucose, self).complete(


### PR DESCRIPTION
Submitting a blood glucose observation takes ~4 seconds (on dev) 99.9% of this time is the decorator that refreshes the 'param' materialized view. This commit disables the decorator for now until the consequences are fully established.