### PR TITLE
Adds current EWS/BG frequency to mobile pages

### DIFF
--- a/nh_eobs_mobile/controllers/main.py
+++ b/nh_eobs_mobile/controllers/main.py
@@ -575,6 +575,16 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
             cr, uid, patient_api.get_followed_patients(
                 cr, uid, []), context=context)
 
+        for patient in patients:
+            if patient.get('frequency'):
+                patient['frequency_string'] = '{:2d} hour(s) {:02d} min(s)'.format(
+                    *divmod(patient.get('frequency'), 60)
+                )
+            if patient.get('bg_frequency'):
+                patient['bg_frequency_string'] = '{:2d} hour(s) {:02d} min(s)'.format(
+                    *divmod(patient.get('bg_frequency'), 60)
+                )
+
         favourites = self.get_user_favourites(uid)
 
         return request.render(
@@ -620,9 +630,16 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
                     {
                         "task_name": activity_detail.display_name,
                         "task_model": str(activity_detail.data_model),
+                        "task_parent": str(activity_detail.creator_id.data_model),
+                        "frequency": self._get_ews_frequency(
+                            activity_detail.creator_id
+                        ),
+                        "bg_frequency": self._get_bg_frequency(
+                            activity_detail.creator_id
+                        ),
                         "activity_id": activity_detail.id,
                         "task_id": activity_detail.data_ref.id,
-                        "input_fields": self._get_input_field(cr, uid, str(activity_detail.data_model), context=context)
+                        "input_fields": self._get_input_field(cr, uid, str(activity_detail.data_model), context=context),
                     }
                 )
 
@@ -633,6 +650,23 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
                 'data': data,
             }
         )
+
+    @staticmethod
+    def _get_ews_frequency(creator_activity):
+        if creator_activity.data_model == 'nh.clinical.patient.observation.ews':
+            return '{:2d} hour(s) {:02d} min(s)'.format(
+                *divmod(creator_activity.data_ref.frequency, 60)
+            )
+        return False
+
+    @staticmethod
+    def _get_bg_frequency(creator_activity):
+        if creator_activity.data_model == \
+                'nh.clinical.patient.observation.blood_glucose':
+            return '{:2d} hour(s) {:02d} min(s)'.format(
+                *divmod(creator_activity.data_ref.frequency, 60)
+            )
+        return False
 
     def _get_input_field(self, cr, uid, obj, context=None):
         """
@@ -867,6 +901,16 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
             cr, uid, task_api.get_activities(
                 cr, uid, [], context=context),
             context=context)
+
+        for task in tasks:
+            if task.get('frequency'):
+                task['frequency_string'] = '{:2d} hour(s) {:02d} min(s)'.format(
+                    *divmod(task.get('frequency'), 60)
+                )
+            if task.get('bg_frequency'):
+                task['bg_frequency_string'] = '{:2d} hour(s) {:02d} min(s)'.format(
+                    *divmod(task.get('bg_frequency'), 60)
+                )
 
         favourites = self.get_user_favourites(uid)
 

--- a/nh_eobs_mobile/controllers/main.py
+++ b/nh_eobs_mobile/controllers/main.py
@@ -577,12 +577,12 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
 
         for patient in patients:
             if patient.get('frequency'):
-                patient['frequency_string'] = '{:2d} hour(s) {:02d} min(s)'.format(
-                    *divmod(patient.get('frequency'), 60)
+                patient['frequency_string'] = self._convert_frequency_to_string(
+                    patient.get('frequency')
                 )
             if patient.get('bg_frequency'):
-                patient['bg_frequency_string'] = '{:2d} hour(s) {:02d} min(s)'.format(
-                    *divmod(patient.get('bg_frequency'), 60)
+                patient['bg_frequency_string'] = self._convert_frequency_to_string(
+                    patient.get('bg_frequency')
                 )
 
         favourites = self.get_user_favourites(uid)
@@ -599,6 +599,10 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
                 'username': request.session['login'],
                 'urls': URLS}
         )
+
+    @staticmethod
+    def _convert_frequency_to_string(frequency):
+        return '{:2d} hour(s) {:02d} min(s)'.format(*divmod(frequency, 60))
 
     @http.route(URLS['escalations'] + '<creator_id>', type='http', auth='user')
     def process_escalations(self, creator_id, *args, **kwargs):
@@ -651,20 +655,18 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
             }
         )
 
-    @staticmethod
-    def _get_ews_frequency(creator_activity):
+    def _get_ews_frequency(self, creator_activity):
         if creator_activity.data_model == 'nh.clinical.patient.observation.ews':
-            return '{:2d} hour(s) {:02d} min(s)'.format(
-                *divmod(creator_activity.data_ref.frequency, 60)
+            return self._convert_frequency_to_string(
+                creator_activity.data_ref.frequency
             )
         return False
 
-    @staticmethod
-    def _get_bg_frequency(creator_activity):
+    def _get_bg_frequency(self, creator_activity):
         if creator_activity.data_model == \
                 'nh.clinical.patient.observation.blood_glucose':
-            return '{:2d} hour(s) {:02d} min(s)'.format(
-                *divmod(creator_activity.data_ref.frequency, 60)
+            return self._convert_frequency_to_string(
+                creator_activity.data_ref.frequency
             )
         return False
 
@@ -904,12 +906,12 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
 
         for task in tasks:
             if task.get('frequency'):
-                task['frequency_string'] = '{:2d} hour(s) {:02d} min(s)'.format(
-                    *divmod(task.get('frequency'), 60)
+                task['frequency_string'] = self._convert_frequency_to_string(
+                    task.get('frequency')
                 )
             if task.get('bg_frequency'):
-                task['bg_frequency_string'] = '{:2d} hour(s) {:02d} min(s)'.format(
-                    *divmod(task.get('bg_frequency'), 60)
+                task['bg_frequency_string'] = self._convert_frequency_to_string(
+                    task.get('bg_frequency')
                 )
 
         favourites = self.get_user_favourites(uid)

--- a/nh_observations/observations.py
+++ b/nh_observations/observations.py
@@ -278,7 +278,7 @@ class NhClinicalPatientObservation(orm.AbstractModel):
                 # TODO Is it right that updating the frequency will
                 # automatically update the date_scheduled to
                 # create_date + frequency?
-                date = context.get('effective_date_terminated') \
+                date = context and context.get('effective_date_terminated') \
                        or obs.activity_id.creator_id.effective_date_terminated
                 scheduled = (dt.strptime(
                     date, DTF)+td(


### PR DESCRIPTION
[O2345] Adds additional information of the current associated frequency of EWS & Blood Glucose observations to tasks cards (EWS & BG Obs only), patient cards and escalation forms for the respective observation types.