### PR TITLE
next_diff_polarity moved from sql materialised view to sql view

### DIFF
--- a/nh_eobs/sql_statements.py
+++ b/nh_eobs/sql_statements.py
@@ -74,7 +74,8 @@ class NHEobsSQL(orm.AbstractModel):
             ELSE patient.patient_identifier
         END AS nhs_number,
         extract(year FROM age(now(), patient.dob)) AS age,
-        ews0.next_diff_polarity ||
+        CASE WHEN ews0.date_scheduled < now() AT TIME ZONE 'UTC'
+                    THEN 'overdue: ' ELSE '' END ||
         CASE
             WHEN ews0.date_scheduled IS NOT NULL THEN
               CASE WHEN extract(days FROM (greatest(now() AT TIME ZONE 'UTC',
@@ -89,7 +90,8 @@ class NHEobsSQL(orm.AbstractModel):
                 ews0.date_scheduled)), 'HH24:MI') || ' hours'
             ELSE to_char((INTERVAL '0s'), 'HH24:MI')
         END AS next_diff,
-        bg0.next_diff_polarity ||
+        CASE WHEN bg0.date_scheduled < now() AT TIME ZONE 'UTC'
+                    THEN 'overdue: ' ELSE '' END ||
         CASE
             WHEN bg0.date_scheduled IS NOT NULL THEN
               CASE WHEN extract(days FROM (greatest(now() AT TIME ZONE 'UTC',

--- a/nh_eobs/wardboard.py
+++ b/nh_eobs/wardboard.py
@@ -1302,8 +1302,6 @@ ews0 as(
                 ews.score,
                 ews.frequency,
                 ews.clinical_risk,
-                case when activity.date_scheduled < now() at time zone 'UTC'
-                    then 'overdue: ' else '' end as next_diff_polarity,
                 case activity.date_scheduled is null
                     when false then justify_hours(greatest(now() at time zone
                     'UTC',activity.date_scheduled) - least(now() at time zone
@@ -1327,8 +1325,6 @@ bg0 as(
                 activity.date_scheduled,
                 bg.id,
                 bg.frequency,
-                case when activity.date_scheduled < now() at time zone 'UTC'
-                    then 'overdue: ' else '' end as next_diff_polarity,
                 case activity.date_scheduled is null
                     when false then justify_hours(greatest(now() at time zone
                     'UTC',activity.date_scheduled) - least(now() at time zone


### PR DESCRIPTION
[O2348] The 'overdue' prefix that appears on nh_clinical_wardboard comes from next_diff_polarity on ews0 & bg0 materialised views. Because of this the string is only updated when certain events occur on the system (eg a patient observation). The wardboard (any any derivative) data should not wait for this event to occur and a user should be able to refresh the page to see the latest (prefix) information.