### PR TITLE
Radio buttons should be required fields on escalation form

### DIFF
--- a/nh_eobs_mobile/views/template.xml
+++ b/nh_eobs_mobile/views/template.xml
@@ -346,6 +346,7 @@
                                                    t-att-id="task['task_id']" value="yes" onclick="yesnoCheck(this)"
                                                    t-att-checked="'checked' if task['task_model']=='nh.clinical.notification.hca' else ''"
                                                    t-att-style="'display: none;' if task['task_model']=='nh.clinical.notification.hca' else ''"
+                                                   required="required"
                                             />
                                             <label t-att-for="task['task_id']"
                                                    t-att-style="'display: none;' if task['task_model']=='nh.clinical.notification.hca' else ''"
@@ -355,6 +356,7 @@
                                             <input type="radio" t-att-name="task['task_id']"
                                                    t-att-id="task['task_id']" value="no" onclick="yesnoCheck(this)"
                                                    t-att-style="'display: none;' if task['task_model']=='nh.clinical.notification.hca' else ''"
+                                                    required="required"
                                             />
                                             <label t-att-for="task['task_id']"
                                                    t-att-style="'display: none;' if task['task_model']=='nh.clinical.notification.hca' else ''"


### PR DESCRIPTION
Escalation tasks, either by consolidated after an obs or individual could be submitted without having selected an option. The change adds the 'required' property to the input. Any additional selection (depending on the radio option yes/no) is added and made required by js manipulation of the DOM.