### PR TITLE
I84 wave 1

### DIFF
--- a/nh_eobs_mental_health/models/nh_clinical_patient_observation_ews.py
+++ b/nh_eobs_mental_health/models/nh_clinical_patient_observation_ews.py
@@ -65,18 +65,11 @@ class NHClinicalPatientObservationEWS(orm.Model):
         ews = activity.data_ref
         patient_spell = activity.spell_activity_id.data_ref
         patient_refusing = patient_spell.refusing_obs
-        patient_refusing_blood_glucose = patient_spell.refusing_obs_blood_glucose
-        on_blood_glucose = activity.data_model == 'nh.clinical.blood.glucose'
 
-        if not ews.is_partial and on_blood_glucose:
-            patient_spell.write({'refusing_obs_blood_glucose': False})
-        elif not ews.is_partial and not on_blood_glucose:
+        if not ews.is_partial:
             patient_spell.write({'refusing_obs': False})
-
-        if ews.is_partial and \
-                ews.partial_reason == 'refused' and \
-                (not on_blood_glucose and not patient_refusing) or \
-                (on_blood_glucose and not patient_refusing_blood_glucose):
+        if ews.is_partial and not patient_refusing \
+                and ews.partial_reason == 'refused':
             api_model = self.pool['nh.eobs.api']
             cron_model = self.pool['ir.cron']
             patient = api_model.get_patients(
@@ -86,10 +79,7 @@ class NHClinicalPatientObservationEWS(orm.Model):
             if patient[0].get('clinical_risk') in higher_risks:
                 days_to_schedule = 7
             schedule_date = datetime.now() + timedelta(days=days_to_schedule)
-            if on_blood_glucose:
-                patient_spell.write({'refusing_obs_blood_glucose': True})
-            else:    
-                patient_spell.write({'refusing_obs': True})
+            patient_spell.write({'refusing_obs': True})
             cron_model.create(cr, SUPERUSER_ID, {
                 'name': 'Clinical Review Task '
                         'for Activity:{0}'.format(activity_id),

--- a/nh_eobs_mental_health/models/nh_clinical_patient_observation_ews.py
+++ b/nh_eobs_mental_health/models/nh_clinical_patient_observation_ews.py
@@ -66,7 +66,7 @@ class NHClinicalPatientObservationEWS(orm.Model):
         patient_spell = activity.spell_activity_id.data_ref
         patient_refusing = patient_spell.refusing_obs
         patient_refusing_blood_glucose = patient_spell.refusing_obs_blood_glucose
-        on_blood_glucose = activity.data_model == 'nh.clinical.blood.glucose':
+        on_blood_glucose = activity.data_model == 'nh.clinical.blood.glucose'
 
         if not ews.is_partial and on_blood_glucose:
             patient_spell.write({'refusing_obs_blood_glucose': False})

--- a/nh_eobs_mental_health/models/nh_clinical_pme_obs_stop.py
+++ b/nh_eobs_mental_health/models/nh_clinical_pme_obs_stop.py
@@ -45,7 +45,8 @@ class NhClinicalObsStop(models.Model):
             )
 
         self.set_obs_stop_flag(True)
-        on_blood_glucose = activity.data_model == 'nh.clinical.blood.glucose'
+        on_blood_glucose = activity.data_model == 'nh.clinical.patient.observation.blood_glucose'
+        import pdb;pdb.set_trace()
         self.set_refusing_obs_flag(False, on_blood_glucose)
         return super_return
 
@@ -105,7 +106,7 @@ class NhClinicalObsStop(models.Model):
         Set the value of the 'refusing_obs' flag on the spell object
 
         :param value: Value to change flag too
-        :param on_blood_glucose: Whether we have a data ref of nh.clinical.blood.glucose
+        :param on_blood_glucose: Whether we have a data model of nh.clinical.patient.observation.blood_glucose
         :return: True
         """
         if on_blood_glucose:

--- a/nh_eobs_mental_health/models/nh_clinical_pme_obs_stop.py
+++ b/nh_eobs_mental_health/models/nh_clinical_pme_obs_stop.py
@@ -46,7 +46,6 @@ class NhClinicalObsStop(models.Model):
 
         self.set_obs_stop_flag(True)
         on_blood_glucose = activity.data_model == 'nh.clinical.patient.observation.blood_glucose'
-        import pdb;pdb.set_trace()
         self.set_refusing_obs_flag(False, on_blood_glucose)
         return super_return
 

--- a/nh_eobs_mental_health/models/nh_clinical_pme_obs_stop.py
+++ b/nh_eobs_mental_health/models/nh_clinical_pme_obs_stop.py
@@ -45,7 +45,8 @@ class NhClinicalObsStop(models.Model):
             )
 
         self.set_obs_stop_flag(True)
-        self.set_refusing_obs_flag(False)
+        on_blood_glucose = activity.data_model == 'nh.clinical.blood.glucose'
+        self.set_refusing_obs_flag(False, on_blood_glucose)
         return super_return
 
     def _cancel_open_food_and_fluid_review_tasks(self):
@@ -99,14 +100,18 @@ class NhClinicalObsStop(models.Model):
         self.spell.obs_stop = value
 
     @api.multi
-    def set_refusing_obs_flag(self, value):
+    def set_refusing_obs_flag(self, value, on_blood_glucose):
         """
         Set the value of the 'refusing_obs' flag on the spell object
 
         :param value: Value to change flag too
+        :param on_blood_glucose: Whether we have a data ref of nh.clinical.blood.glucose
         :return: True
         """
-        self.spell.refusing_obs = value
+        if on_blood_glucose:
+            self.spell.refusing_obs_blood_glucose = value
+        else:
+            self.spell.refusing_obs = value
 
     @api.model
     def cancel_open_ews(self, spell_activity_id, cancel_reason_id=None):

--- a/nh_eobs_mental_health/models/nh_clinical_spell.py
+++ b/nh_eobs_mental_health/models/nh_clinical_spell.py
@@ -13,11 +13,15 @@ class NHClinicalSpell(orm.Model):
     _columns = {
         'obs_stop': fields.boolean('Stop Observations for patient?'),
         'rapid_tranq': fields.boolean('Patient on Rapid Tranquilisation?'),
-        'refusing_obs': fields.boolean('Patient Refusing Observations?')
+        'refusing_obs': fields.boolean('Patient Refusing Observations?'),
+        # DEBT, cannot move refusing obs flag to activity model
+        # as the current data model (i.e wardboard) will not support this
+        'refusing_obs_blood_glucose': fields.boolean('Patient Refusing Blood Glucose Observations?'),
     }
 
     _defaults = {
         'obs_stop': False,
         'rapid_tranq': False,
-        'refusing_obs': False
+        'refusing_obs': False,
+        'refusing_obs_blood_glucose': False,
     }

--- a/nh_eobs_mental_health/models/nh_clinical_wardboard.py
+++ b/nh_eobs_mental_health/models/nh_clinical_wardboard.py
@@ -320,7 +320,8 @@ class NHClinicalWardboard(orm.Model):
                 elif spell.get('refusing_obs'):
                     rec['frequency'] = 'Refused - {0}'.format(rec['frequency'])
                     rec['next_diff'] = 'Refused - {0}'.format(rec['next_diff'])
-                elif spell.get('refusing_obs_blood_glucose'):
+                if spell.get('refusing_obs_blood_glucose'):
+                    rec['bg_frequency'] = 'Refused - {0}'.format(rec['bg_frequency'])
                     rec['next_blood_glucose_diff'] = 'Refused - {0}'.format(rec['next_blood_glucose_diff'])
         if was_single_record:
             return res[0]

--- a/nh_eobs_mental_health/models/nh_clinical_wardboard.py
+++ b/nh_eobs_mental_health/models/nh_clinical_wardboard.py
@@ -293,7 +293,8 @@ class NHClinicalWardboard(orm.Model):
                     cr, user, spell_id, [
                         'obs_stop',
                         'rapid_tranq',
-                        'refusing_obs'
+                        'refusing_obs',
+                        'refusing_obs_blood_glucose',
                     ],
                     context=context)
                 rec['rapid_tranq'] = spell.get('rapid_tranq')
@@ -319,6 +320,7 @@ class NHClinicalWardboard(orm.Model):
                 elif spell.get('refusing_obs'):
                     rec['frequency'] = 'Refused - {0}'.format(rec['frequency'])
                     rec['next_diff'] = 'Refused - {0}'.format(rec['next_diff'])
+                elif spell.get('refusing_obs_blood_glucose'):
                     rec['next_blood_glucose_diff'] = 'Refused - {0}'.format(rec['next_blood_glucose_diff'])
         if was_single_record:
             return res[0]

--- a/nh_eobs_mental_health/models/nh_eobs_api.py
+++ b/nh_eobs_mental_health/models/nh_eobs_api.py
@@ -84,6 +84,7 @@ class NHeObsAPI(orm.AbstractModel):
                 cr, uid, spell_id, [
                     'obs_stop',
                     'refusing_obs',
+                    'refusing_obs_blood_glucose',
                     'activity_id'
                 ], context=context)
             obs_stopped = spell.get('obs_stop')
@@ -97,6 +98,10 @@ class NHeObsAPI(orm.AbstractModel):
                 spell_model.write(
                     cr, uid, spell_id,
                     {'refusing_obs': False}, context=context)
+            if spell.get('refusing_obs_blood_glucose'):
+                spell_model.write(
+                    cr, uid, spell_id,
+                    {'refusing_obs_blood_glucose': False}, context=context)
         res = super(NHeObsAPI, self).transfer(
             cr, uid, hospital_number, data, context=None)
         return res
@@ -129,12 +134,17 @@ class NHeObsAPI(orm.AbstractModel):
             spell = spell_model.read(
                 cr, uid, spell_id, [
                     'refusing_obs',
+                    'refusing_obs_blood_glucose',
                     'activity_id'
                 ], context=context)
             if spell.get('refusing_obs'):
                 spell_model.write(
                     cr, uid, spell_id,
                     {'refusing_obs': False}, context=context)
+            if spell.get('refusing_obs_blood_glucose'):
+                spell_model.write(
+                    cr, uid, spell_id,
+                    {'refusing_obs_blood_glucose': False}, context=context)
         res = super(NHeObsAPI, self).discharge(
             cr, uid, hospital_number, data, context=None)
         return res

--- a/nh_eobs_mental_health/sql/refused_observations.py
+++ b/nh_eobs_mental_health/sql/refused_observations.py
@@ -134,7 +134,7 @@ class RefusedObservationsSQL(orm.AbstractModel):
             'LIMIT 1'
             ') '
             'THEN \'NoScore\' '
-            'WHEN spell.refusing_obs = true '
+            'WHEN (spell.refusing_obs = TRUE OR spell.refusing_obs_blood_glucose = TRUE)'
             'THEN \'Refused\' '
         )
 
@@ -151,6 +151,7 @@ class RefusedObservationsSQL(orm.AbstractModel):
             'end as deadline_time,',
             'end as deadline_time, '
             'spell.refusing_obs AS refusal_in_effect, '
+            'spell.refusing_obs_blood_glucose AS refusal_in_effect_blood_glucose, '
         )
         return sql.format(activity_ids=activity_ids_sql)
 
@@ -167,6 +168,7 @@ class RefusedObservationsSQL(orm.AbstractModel):
             'patient.other_identifier,',
             'patient.other_identifier, '
             'spell.refusing_obs AS refusal_in_effect, '
+            'spell.refusing_obs_blood_glucose AS refusal_in_effect_blood_glucose, '
             'spell.rapid_tranq AS rapid_tranq, '
         )
         return sql.format(spell_ids=spell_ids)

--- a/nh_eobs_mental_health/sql/ward_dashboard.py
+++ b/nh_eobs_mental_health/sql/ward_dashboard.py
@@ -99,7 +99,7 @@ class WardDashboardSQL(orm.AbstractModel):
         SELECT  ward_beds.location_id,
                 coalesce(
                   sum(
-                    CASE WHEN spell.refusing_obs = TRUE THEN 1 ELSE 0 END),0)
+                    CASE WHEN (spell.refusing_obs = TRUE OR spell.refusing_obs_blood_glucose = TRUE) THEN 1 ELSE 0 END),0)
                 AS count
           FROM nh_clinical_spell AS spell
           LEFT JOIN ward_beds


### PR DESCRIPTION
Handle refused blood glucose observations seperately to refused observations.

Hopefully this also cross-covers any other places where a refused observation would be taken into account.

This has been done by adding a new column to spell, as opposed to storing it on the activity, due to the current data model not supporting storing/pulling the value from activity due to the way most of the data flow relies on nh.activity.spell, and spells having a o2m relation to activities.