### PR TITLE
[FIX] Printing report unable to handle a cancelled task

### DIFF
--- a/nh_eobs_mental_health/report/refused_observations.py
+++ b/nh_eobs_mental_health/report/refused_observations.py
@@ -217,6 +217,8 @@ class MentalHealthObservationReport(models.AbstractModel):
                 'date_terminated': date_terminated,
                 'user_id': user.name
             }
+        elif review_state == 'cancelled':
+            return 'Task Cancelled'
         raise ValueError(
             "Unexpected state '{}' for {} task.".format(
                 review_state, task_name.title())


### PR DESCRIPTION
As tasks can now be cancelled by the system (for being to old), the NEWS report needs to be able to handle a task that was cancelled.

Fixes #16517