### PR TITLE
[FIX] Refused BG shouldn't show in refused kanban column

### DIFF
--- a/nh_eobs_mental_health/sql/refused_observations.py
+++ b/nh_eobs_mental_health/sql/refused_observations.py
@@ -134,7 +134,7 @@ class RefusedObservationsSQL(orm.AbstractModel):
             'LIMIT 1'
             ') '
             'THEN \'NoScore\' '
-            'WHEN (spell.refusing_obs = TRUE OR spell.refusing_obs_blood_glucose = TRUE)'
+            'WHEN (spell.refusing_obs = TRUE)'
             'THEN \'Refused\' '
         )
 


### PR DESCRIPTION
Acutity board should only show patients that have refused NEWS obs in the refused column.

Fixes #16518