### PR TITLE
16529

### DIFF
--- a/nh_eobs/static/src/js/nh_eobs_v0_0_1.js
+++ b/nh_eobs/static/src/js/nh_eobs_v0_0_1.js
@@ -503,12 +503,6 @@ openerp.nh_eobs = function (instance) {
             this.set({'value': value_});
             this.render_chart();
         },
-        localise_datetime: function (datetime) {
-            var pattern = /(\d{4})\-(\d{2})\-(\d{2})\s(\d{2})\:(\d{2})\:(\d{2})/;
-            var match = pattern.exec(datetime);
-            var dt = new Date(Date.UTC(match[1], match[2] - 1, match[3], match[4], match[5], match[6]));
-            return dt.getFullYear() + "-" + (dt.getMonth() + 1) + "-" + dt.getDate() + " " + dt.getHours() + ":" + dt.getMinutes() + ":" + dt.getSeconds();
-        },
         render_chart: function () {
             this.model = new instance.web.Model('nh.eobs.api');
             this.o2targetModel = new instance.web.Model('nh.clinical.patient.o2target');
@@ -533,10 +527,6 @@ openerp.nh_eobs = function (instance) {
 
                 $(svg.el).html('');
                 if (records.length > 0) {
-                    for (var i = 0; i < records.length; i++) {
-                        var ed = records[i].effective_date_terminated;
-                        records[i].effective_date_terminated = self.localise_datetime(ed)
-                    }
                     var obs = records.reverse();
 
                     obs.forEach(function (d) {

--- a/nh_eobs_mobile/controllers/main.py
+++ b/nh_eobs_mobile/controllers/main.py
@@ -744,8 +744,9 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
             obj_model = request.registry[task['model']]
             data_record = obj_model.browse(cr, uid, task['id'], context=context)
             activity = data_record.activity_id
+            effective_date = activity.creator_id.effective_date_terminated
             vals = {
-                'effective_date_terminated': activity.creator_id.effective_date_terminated,
+                'effective_date_terminated': effective_date,
             }
             if task.get('cancel'):
                 vals.update({
@@ -757,6 +758,9 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
                 })
             obj_model.submit(cr, uid, activity.id, vals, context=context)
             obj_nh_activity.complete(cr, uid, activity.id, context=context)
+
+            # Calling complete method on the activity resets the effective date
+            activity.effective_date_terminated = effective_date
 
             if task.get('cancel') and activity.creator_id.data_model == 'nh.clinical.patient.observation.blood_glucose':
                 self._cancel_next_blood_glucose(cr, uid, obj_nh_activity, activity,

--- a/nh_food_and_fluid/report/nh_clinical_observation_report.py
+++ b/nh_food_and_fluid/report/nh_clinical_observation_report.py
@@ -47,3 +47,13 @@ class NhClinicalObservationReport(models.Model):
         food_and_fluid_model.format_many_2_many_fields(obs_list,
                                                        ['recorded_concerns',
                                                         'dietary_needs'])
+
+    def _localise_and_format_datetimes(self, report_data):
+        super(NhClinicalObservationReport, self)._localise_and_format_datetimes(report_data)
+
+        if 'food_and_fluid' in report_data:
+            for obs in report_data.get('food_and_fluid'):
+                for record in obs['observations']:
+                    self._localise_dict_time(record, 'date_started')
+                    self._localise_dict_time(record, 'date_terminated')
+                    self._localise_dict_time(record, 'effective_date_terminated')

--- a/nh_food_and_fluid/views/observation_report_template.xml
+++ b/nh_food_and_fluid/views/observation_report_template.xml
@@ -25,7 +25,8 @@
             <table class="striped col-xs-12 row">
                 <thead>
                     <tr>
-                        <th class="col-xs-3">Date / Time</th>
+                        <th class="col-xs-2">Effective Date</th>
+                        <th class="col-xs-2">Submitted Date</th>
                         <th class="col-xs-1">Recorded Concern</th>
                         <th class="col-xs-1">Dietary Needs</th>
                         <th class="col-xs-1">Fluid Intake</th>
@@ -40,7 +41,8 @@
                 <tbody>
                     <t t-foreach="observation_period['observations']" t-as="observation">
                         <tr>
-                            <td class="col-xs-3"><t t-esc="observation['date_terminated']"/></td>
+                            <td class="col-xs-2"><t t-esc="observation['effective_date_terminated']"/></td>
+                            <td class="col-xs-2"><t t-esc="observation['date_terminated']"/></td>
                             <td class="col-xs-1"><t t-esc="observation['values']['recorded_concerns']"/></td>
                             <td class="col-xs-1"><t t-esc="observation['values']['dietary_needs']"/></td>
                             <td class="col-xs-1"><t t-esc="observation['values']['fluid_taken']"/></td>

--- a/nh_neurological/report/nh_clinical_observation_report.py
+++ b/nh_neurological/report/nh_clinical_observation_report.py
@@ -18,9 +18,10 @@ class NhClinicalPatientObservationReport(models.AbstractModel):
         return report_data
 
     def _localise_and_format_datetimes(self, report_data):
-        super(NhClinicalPatientObservationReport, self)\
-            ._localise_and_format_datetimes(report_data)
+        super(NhClinicalPatientObservationReport, self)._localise_and_format_datetimes(report_data)
         for obs in report_data.get('neurological', []):
+            self._localise_dict_time(obs, 'date_started')
+            self._localise_dict_time(obs, 'date_terminated')
             self._localise_dict_time(obs, 'effective_date_terminated')
 
     def get_neurological_observations(self, data):

--- a/nh_neurological/views/observation_report_template.xml
+++ b/nh_neurological/views/observation_report_template.xml
@@ -48,13 +48,14 @@
                 <thead>
                     <tr>
                         <!-- Blank space above Date column. -->
-                        <th colspan="1" class="col-xs-3"></th>
+                        <th colspan="2" class="col-xs-5"></th>
                         <th colspan="4" class="border-right col-xs-4"><h4>Coma Scale</h4></th>
                         <th colspan="4" class="col-xs-4 border-right"><h4>Pupils</h4></th>
                         <th colspan="4" class="col-xs-4 border-right"><h4>Limbs</h4></th>
                     </tr>
                     <tr>
-                        <th class="col-xs-3 neuro-table-header">Date</th>
+                        <th class="col-xs-2 neuro-table-header">Effective Date</th>
+                        <th class="col-xs-2 neuro-table-header">Submitted Date</th>
                         <th class="col-xs-1 neuro-table-header">Coma Scale Total score</th>
                         <th class="col-xs-1 neuro-table-header">Eyes</th>
                         <th class="col-xs-1 neuro-table-header">Verbal</th>
@@ -73,7 +74,8 @@
                 <tbody>
                     <t t-foreach="neurological" t-as="observation">
                         <tr>
-                            <td class="col-xs-3"><t t-esc="observation['date_terminated']"/></td>
+                            <td class="col-xs-2"><t t-esc="observation['effective_date_terminated']"/></td>
+                            <td class="col-xs-2"><t t-esc="observation['date_terminated']"/></td>
                             <td class="col-xs-1"><t t-esc="observation['values']['score']"/></td>
                             <td class="col-xs-1"><t t-esc="observation['values']['eyes']"/></td>
                             <td class="col-xs-1"><t t-esc="observation['values']['verbal']"/></td>

--- a/nh_observations/observations.py
+++ b/nh_observations/observations.py
@@ -417,7 +417,7 @@ class NhClinicalPatientObservation(orm.AbstractModel):
 
         if convert_datetimes_to_client_timezone:
             datetime_fields = ['date_terminated', 'create_date',
-                               'write_date', 'date_started']
+                               'write_date', 'date_started', 'effective_date_terminated']
             self._convert_datetime_fields_to_client_timezone(
                 obs_dict_list, datetime_fields)
 

--- a/nh_weight/report/nh_clinical_patient_observation_report.py
+++ b/nh_weight/report/nh_clinical_patient_observation_report.py
@@ -40,6 +40,7 @@ class NhClinicalPatientObservationReport(models.AbstractModel):
         super(NhClinicalPatientObservationReport, self)\
             ._localise_and_format_datetimes(report_data)
         for obs in report_data.get('weights', []):
+            self._localise_dict_time(obs['values'], 'date_terminated')
             self._localise_dict_time(obs['values'], 'effective_date_terminated')
 
     @staticmethod

--- a/nh_weight/views/observation_report_template.xml
+++ b/nh_weight/views/observation_report_template.xml
@@ -34,21 +34,23 @@
                         <table class="striped col-xs-12 row">
                             <thead>
                                 <tr>
-                                    <th class="col-xs-3">Date</th>
+                                    <th class="col-xs-2">Effective Date</th>
+                                    <th class="col-xs-2">Submitted Date</th>
                                     <th class="col-xs-2">Weight (kg)</th>
                                     <th class="col-xs-2">Waist Measurement (cm)</th>
                                     <th class="col-xs-2">BMI</th>
-                                    <th class="col-xs-3">User</th>
+                                    <th class="col-xs-2">User</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 <t t-foreach="weights" t-as="weight">
                                     <tr>
-                                        <td class="col-xs-3"><t t-esc="weight.get('values', {}).get('date_terminated')"/></td>
+                                        <td class="col-xs-2"><t t-esc="weight.get('values', {}).get('effective_date_terminated')"/></td>
+                                        <td class="col-xs-2"><t t-esc="weight.get('values', {}).get('date_terminated')"/></td>
                                         <td class="col-xs-2"><t t-esc="weight.get('values', {}).get('weight')"/></td>
                                         <td class="col-xs-2"><t t-esc="weight.get('values', {}).get('waist_measurement')"/></td>
                                         <td class="col-xs-2"><t t-esc="weight.get('values', {}).get('score')"/></td>
-                                        <td class="col-xs-3"><t t-esc="weight.get('values', {}).get('terminate_uid', (None,None))[1]"/></td>
+                                        <td class="col-xs-2"><t t-esc="weight.get('values', {}).get('terminate_uid', (None,None))[1]"/></td>
                                     </tr>
                                 </t>
                             </tbody>


### PR DESCRIPTION
* Reported as Food and Fluid not reporting dates in BST, but after further testing this was found true for other observations. The initial fix for F&F resulted in other obs that were previously correct were now wrong. This highlighted that the original fix for BST issue by changing the javascript was incorrect. This commit removed the previous javascript changes and updates observation models 'convert datetime' methods with the correct fields to be converted.
* Printed report observations don't show effective date
*effective_date_terminated not updated in escalation activities