### PR TITLE
[FIX] Transferred patient has placement task stuck as scheduled

### DIFF
--- a/nh_clinical/operations.py
+++ b/nh_clinical/operations.py
@@ -354,7 +354,7 @@ class nh_clinical_patient_placement(orm.Model):
         if vals.get('location_id'):
             location_pool = self.pool['nh.clinical.location']
             available_ids = location_pool.get_available_location_ids(
-                cr, uid, ['bed'], context=context)
+                cr, uid, ['ward', 'bed'], context=context)
             if vals['location_id'] not in available_ids:
                 raise osv.except_osv(
                     "Patient Placement Error!",


### PR DESCRIPTION
When a A02 HL7 message is sent (to transfer a patient between wards), the existing placement task is cancelled (from state of scheduled) and a new one is created with a state of scheduled.

When a A03 HL7 message is sent (to discharge a patient), the scheduled placement task remains in a state of scheduled and causes an error if the same patient is admitted again.

As bed assignment is no longer used, the placement task should be processed as completed as soon as it is created and the placement task use the ward as the location.

Fixes #16865