### PR TITLE
[FIX] Removing internal calls to refresh materialized views

### DIFF
--- a/nh_eobs/base_extension.py
+++ b/nh_eobs/base_extension.py
@@ -100,17 +100,3 @@ class nh_ui_location(orm.Model):
         return super(nh_ui_location, self).search(
             cr, uid, domain, offset=offset, limit=limit, order=order,
             context=context, count=count)
-
-    def create(self, cr, uid, vals, context=None):
-        """
-        Extends Odoo's :meth:`create()<openerp.models.Model.create>`,
-        refreshing the materialized view `ward_locations`.
-        """
-
-        res = super(nh_ui_location, self).create(
-            cr, uid, vals, context=context)
-        sql = """
-                refresh materialized view ward_locations;
-        """
-        cr.execute(sql)
-        return res

--- a/nh_eobs/observation_extension.py
+++ b/nh_eobs/observation_extension.py
@@ -1,13 +1,11 @@
 # Part of Open eObs. See LICENSE file for full copyright and licensing details.
 # -*- coding: utf-8 -*-
 from openerp.osv import orm
-from openerp.addons.nh_eobs.helpers import refresh_materialized_views
 
 
 class nh_clinical_patient_observation_ews(orm.Model):
     _inherit = 'nh.clinical.patient.observation.ews'
 
-    @refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_ews, self).complete(
@@ -17,7 +15,6 @@ class nh_clinical_patient_observation_ews(orm.Model):
 class nh_clinical_patient_o2target(orm.Model):
     _inherit = 'nh.clinical.patient.o2target'
 
-    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_o2target, self).complete(
@@ -27,7 +24,6 @@ class nh_clinical_patient_o2target(orm.Model):
 class nh_clinical_notification_frequency(orm.Model):
     _inherit = 'nh.clinical.notification.frequency'
 
-    @refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_notification_frequency, self).complete(
@@ -37,7 +33,6 @@ class nh_clinical_notification_frequency(orm.Model):
 class nh_clinical_patient_observation_height(orm.Model):
     _inherit = 'nh.clinical.patient.observation.height'
 
-    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_height, self).complete(
@@ -47,7 +42,6 @@ class nh_clinical_patient_observation_height(orm.Model):
 class nh_clinical_patient_observation_blood_product(orm.Model):
     _inherit = 'nh.clinical.patient.observation.blood_product'
 
-    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_blood_product, self).complete(
@@ -57,7 +51,6 @@ class nh_clinical_patient_observation_blood_product(orm.Model):
 class nh_clinical_patient_observation_pain(orm.Model):
     _inherit = 'nh.clinical.patient.observation.pain'
 
-    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_pain, self).complete(
@@ -67,7 +60,6 @@ class nh_clinical_patient_observation_pain(orm.Model):
 class nh_clinical_patient_observation_urine_output(orm.Model):
     _inherit = 'nh.clinical.patient.observation.urine_output'
 
-    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_urine_output, self).complete(
@@ -77,7 +69,6 @@ class nh_clinical_patient_observation_urine_output(orm.Model):
 class nh_clinical_patient_observation_bowels_open(orm.Model):
     _inherit = 'nh.clinical.patient.observation.bowels_open'
 
-    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_bowels_open, self).complete(
@@ -87,7 +78,6 @@ class nh_clinical_patient_observation_bowels_open(orm.Model):
 class nh_clinical_patient_mrsa(orm.Model):
     _inherit = 'nh.clinical.patient.mrsa'
 
-    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_mrsa, self).complete(
@@ -97,7 +87,6 @@ class nh_clinical_patient_mrsa(orm.Model):
 class nh_clinical_patient_diabetes(orm.Model):
     _inherit = 'nh.clinical.patient.diabetes'
 
-    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_diabetes, self).complete(
@@ -107,7 +96,6 @@ class nh_clinical_patient_diabetes(orm.Model):
 class nh_clinical_patient_palliative_care(orm.Model):
     _inherit = 'nh.clinical.patient.palliative_care'
 
-    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_palliative_care, self).complete(
@@ -117,7 +105,6 @@ class nh_clinical_patient_palliative_care(orm.Model):
 class nh_clinical_patient_post_surgery(orm.Model):
     _inherit = 'nh.clinical.patient.post_surgery'
 
-    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_post_surgery, self).complete(
@@ -127,7 +114,6 @@ class nh_clinical_patient_post_surgery(orm.Model):
 class nh_clinical_patient_critical_care(orm.Model):
     _inherit = 'nh.clinical.patient.critical_care'
 
-    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_critical_care, self).complete(
@@ -137,7 +123,6 @@ class nh_clinical_patient_critical_care(orm.Model):
 class nh_clinical_patient_urine_output_target(orm.Model):
     _inherit = 'nh.clinical.patient.uotarget'
 
-    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_urine_output_target, self).complete(
@@ -147,7 +132,6 @@ class nh_clinical_patient_urine_output_target(orm.Model):
 class nh_clinical_patient_pbp_monitoring(orm.Model):
     _inherit = 'nh.clinical.patient.pbp_monitoring'
 
-    @refresh_materialized_views('pbp')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_pbp_monitoring, self).complete(

--- a/nh_eobs_mental_health/models/nh_clinical_wardboard.py
+++ b/nh_eobs_mental_health/models/nh_clinical_wardboard.py
@@ -121,7 +121,6 @@ class NHClinicalWardboard(orm.Model):
             'view_id': view_id
         }
 
-    @helpers.v8_refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
     @api.multi
     def start_obs_stop(self, reasons, spell_id, spell_activity_id):
         """
@@ -165,7 +164,6 @@ class NHClinicalWardboard(orm.Model):
         obs_stop = activity.data_ref
         obs_stop.start(activity_id)
 
-    @helpers.v8_refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
     @api.multi
     def end_obs_stop(self, cancellation=False):
         """

--- a/nh_eobs_mobile/controllers/main.py
+++ b/nh_eobs_mobile/controllers/main.py
@@ -766,11 +766,6 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
                 self._cancel_next_blood_glucose(cr, uid, obj_nh_activity, activity,
                                                 context)
 
-            cr.execute(
-                'refresh materialized view ews0;\n'
-                'refresh materialized view bg0;'
-            )
-
         if tasks:
             self._check_custom_frequency(tasks[0])
         return self.get_tasks()
@@ -791,7 +786,6 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
             next_ews_activity = obj_nh_activity.browse(cr, uid, next_ews_activity_id, context=context)
             next_ews_activity.data_ref.write(
                 {'frequency': spell.custom_frequency})
-            request.cr.execute("""refresh materialized view ews0;""")
 
     @staticmethod
     def _cancel_next_blood_glucose(cr, uid, obj_nh_activity, activity, context):
@@ -812,7 +806,6 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
             ('patient_id', '=', activity.patient_id.id)
         ], context=context)
         obj_nh_activity.cancel(cr, uid, next_blood_glucose_activity_id, context=context)
-        cr.execute("""refresh materialized view bg0;""")
 
     @http.route(URLS['share_patient_list'], type='http', auth='user')
     def get_share_patients(self, *args, **kw):


### PR DESCRIPTION
The refresh of materialized views is being moved to a sibling container that will run on a timed interval. This commit removes all calls (decorators or otherwise) to 'refresh materialized view X'

Fixes #17138