### PR TITLE
Replace direct calls to refresh materialized view with adding them to a queue

### DIFF
--- a/nh_eobs/base_extension.py
+++ b/nh_eobs/base_extension.py
@@ -100,3 +100,17 @@ class nh_ui_location(orm.Model):
         return super(nh_ui_location, self).search(
             cr, uid, domain, offset=offset, limit=limit, order=order,
             context=context, count=count)
+
+    def create(self, cr, uid, vals, context=None):
+        """
+        Extends Odoo's :meth:`create()<openerp.models.Model.create>`,
+        refreshing the materialized view `ward_locations`.
+        """
+
+        res = super(nh_ui_location, self).create(
+            cr, uid, vals, context=context)
+        sql = """
+                refresh materialized view ward_locations;
+        """
+        cr.execute(sql)
+        return res

--- a/nh_eobs/base_extension.py
+++ b/nh_eobs/base_extension.py
@@ -103,14 +103,17 @@ class nh_ui_location(orm.Model):
 
     def create(self, cr, uid, vals, context=None):
         """
-        Extends Odoo's :meth:`create()<openerp.models.Model.create>`,
-        refreshing the materialized view `ward_locations`.
+        Adds 'ward_locations' to the nh.clinical.materialized.queue
+        :param cr: Database cursor
+        :param uid: User ID
+        :param vals: <dict>
+        :param context: <dict>
+        :return:
         """
-
-        res = super(nh_ui_location, self).create(
-            cr, uid, vals, context=context)
-        sql = """
-                refresh materialized view ward_locations;
-        """
-        cr.execute(sql)
+        res = super(nh_ui_location, self).create(cr, uid, vals, context=context)
+        vals = {
+            "name": "Refresh Ward Locations",
+            "view_name": "ward_locations"
+        }
+        self.pool.get("nh.clinical.materialized.queue").create(cr, uid, vals, context=context)
         return res

--- a/nh_eobs/helpers.py
+++ b/nh_eobs/helpers.py
@@ -47,3 +47,36 @@ def v8_refresh_materialized_views(*views):
             return result
         return _complete
     return _refresh_materialized_views
+
+
+def v7_materialized_queue(*views):
+
+    def _add_to_queue(f):
+        @wraps(f)
+        def _complete(*args, **kwargs):
+            self, cr, uid = args[:3]
+            result = f(*args, **kwargs)
+            for view in views:
+                self.pool.get("nh.clinical.materialized.queue").create(cr, uid, {
+                    "name": "Refresh {}".format(view),
+                    "view_name": view
+                }, context={})
+            return result
+        return _complete
+    return _add_to_queue
+
+
+def v8_materialized_queue(*views):
+    def _add_to_queue(f):
+        @wraps(f)
+        def _complete(*args, **kwargs):
+            self = args[0]
+            result = f(*args, **kwargs)
+            for view in views:
+                self.env["nh.clinical.materialized.queue"].create({
+                    "name": "Refresh {}".format(view),
+                    "view_name": view,
+                })
+            return result
+        return _complete
+    return _add_to_queue

--- a/nh_eobs/models/__init__.py
+++ b/nh_eobs/models/__init__.py
@@ -1,1 +1,2 @@
 from . import nh_clinical_patient_monitoring_exception
+from . import nh_clinical_materialized_queue

--- a/nh_eobs/models/nh_clinical_materialized_queue.py
+++ b/nh_eobs/models/nh_clinical_materialized_queue.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models, fields, api
+
+
+class NhClinicalMaterializedQueue(models.Model):
+    _name = 'nh.clinical.materialized.queue'
+    _description = "NH Clinical Materialized Queue"
+
+    name = fields.Char()
+    view_name = fields.Char()

--- a/nh_eobs/observation_extension.py
+++ b/nh_eobs/observation_extension.py
@@ -1,11 +1,13 @@
 # Part of Open eObs. See LICENSE file for full copyright and licensing details.
 # -*- coding: utf-8 -*-
 from openerp.osv import orm
+from openerp.addons.nh_eobs.helpers import refresh_materialized_views
 
 
 class nh_clinical_patient_observation_ews(orm.Model):
     _inherit = 'nh.clinical.patient.observation.ews'
 
+    @refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_ews, self).complete(
@@ -15,6 +17,7 @@ class nh_clinical_patient_observation_ews(orm.Model):
 class nh_clinical_patient_o2target(orm.Model):
     _inherit = 'nh.clinical.patient.o2target'
 
+    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_o2target, self).complete(
@@ -24,6 +27,7 @@ class nh_clinical_patient_o2target(orm.Model):
 class nh_clinical_notification_frequency(orm.Model):
     _inherit = 'nh.clinical.notification.frequency'
 
+    @refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_notification_frequency, self).complete(
@@ -33,6 +37,7 @@ class nh_clinical_notification_frequency(orm.Model):
 class nh_clinical_patient_observation_height(orm.Model):
     _inherit = 'nh.clinical.patient.observation.height'
 
+    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_height, self).complete(
@@ -42,6 +47,7 @@ class nh_clinical_patient_observation_height(orm.Model):
 class nh_clinical_patient_observation_blood_product(orm.Model):
     _inherit = 'nh.clinical.patient.observation.blood_product'
 
+    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_blood_product, self).complete(
@@ -51,6 +57,7 @@ class nh_clinical_patient_observation_blood_product(orm.Model):
 class nh_clinical_patient_observation_pain(orm.Model):
     _inherit = 'nh.clinical.patient.observation.pain'
 
+    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_pain, self).complete(
@@ -60,6 +67,7 @@ class nh_clinical_patient_observation_pain(orm.Model):
 class nh_clinical_patient_observation_urine_output(orm.Model):
     _inherit = 'nh.clinical.patient.observation.urine_output'
 
+    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_urine_output, self).complete(
@@ -69,6 +77,7 @@ class nh_clinical_patient_observation_urine_output(orm.Model):
 class nh_clinical_patient_observation_bowels_open(orm.Model):
     _inherit = 'nh.clinical.patient.observation.bowels_open'
 
+    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_bowels_open, self).complete(
@@ -78,6 +87,7 @@ class nh_clinical_patient_observation_bowels_open(orm.Model):
 class nh_clinical_patient_mrsa(orm.Model):
     _inherit = 'nh.clinical.patient.mrsa'
 
+    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_mrsa, self).complete(
@@ -87,6 +97,7 @@ class nh_clinical_patient_mrsa(orm.Model):
 class nh_clinical_patient_diabetes(orm.Model):
     _inherit = 'nh.clinical.patient.diabetes'
 
+    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_diabetes, self).complete(
@@ -96,6 +107,7 @@ class nh_clinical_patient_diabetes(orm.Model):
 class nh_clinical_patient_palliative_care(orm.Model):
     _inherit = 'nh.clinical.patient.palliative_care'
 
+    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_palliative_care, self).complete(
@@ -105,6 +117,7 @@ class nh_clinical_patient_palliative_care(orm.Model):
 class nh_clinical_patient_post_surgery(orm.Model):
     _inherit = 'nh.clinical.patient.post_surgery'
 
+    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_post_surgery, self).complete(
@@ -114,6 +127,7 @@ class nh_clinical_patient_post_surgery(orm.Model):
 class nh_clinical_patient_critical_care(orm.Model):
     _inherit = 'nh.clinical.patient.critical_care'
 
+    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_critical_care, self).complete(
@@ -123,6 +137,7 @@ class nh_clinical_patient_critical_care(orm.Model):
 class nh_clinical_patient_urine_output_target(orm.Model):
     _inherit = 'nh.clinical.patient.uotarget'
 
+    @refresh_materialized_views('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_urine_output_target, self).complete(
@@ -132,6 +147,7 @@ class nh_clinical_patient_urine_output_target(orm.Model):
 class nh_clinical_patient_pbp_monitoring(orm.Model):
     _inherit = 'nh.clinical.patient.pbp_monitoring'
 
+    @refresh_materialized_views('pbp')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_pbp_monitoring, self).complete(

--- a/nh_eobs/observation_extension.py
+++ b/nh_eobs/observation_extension.py
@@ -1,13 +1,13 @@
 # Part of Open eObs. See LICENSE file for full copyright and licensing details.
 # -*- coding: utf-8 -*-
 from openerp.osv import orm
-from openerp.addons.nh_eobs.helpers import refresh_materialized_views
+from openerp.addons.nh_eobs.helpers import v7_materialized_queue
 
 
 class nh_clinical_patient_observation_ews(orm.Model):
     _inherit = 'nh.clinical.patient.observation.ews'
 
-    @refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
+    @v7_materialized_queue('ews0', 'ews1', 'ews2', 'bg0')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_ews, self).complete(
@@ -17,7 +17,7 @@ class nh_clinical_patient_observation_ews(orm.Model):
 class nh_clinical_patient_o2target(orm.Model):
     _inherit = 'nh.clinical.patient.o2target'
 
-    @refresh_materialized_views('param')
+    @v7_materialized_queue('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_o2target, self).complete(
@@ -27,7 +27,7 @@ class nh_clinical_patient_o2target(orm.Model):
 class nh_clinical_notification_frequency(orm.Model):
     _inherit = 'nh.clinical.notification.frequency'
 
-    @refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
+    @v7_materialized_queue('ews0', 'ews1', 'ews2', 'bg0')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_notification_frequency, self).complete(
@@ -37,7 +37,7 @@ class nh_clinical_notification_frequency(orm.Model):
 class nh_clinical_patient_observation_height(orm.Model):
     _inherit = 'nh.clinical.patient.observation.height'
 
-    @refresh_materialized_views('param')
+    @v7_materialized_queue('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_height, self).complete(
@@ -47,7 +47,7 @@ class nh_clinical_patient_observation_height(orm.Model):
 class nh_clinical_patient_observation_blood_product(orm.Model):
     _inherit = 'nh.clinical.patient.observation.blood_product'
 
-    @refresh_materialized_views('param')
+    @v7_materialized_queue('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_blood_product, self).complete(
@@ -57,7 +57,7 @@ class nh_clinical_patient_observation_blood_product(orm.Model):
 class nh_clinical_patient_observation_pain(orm.Model):
     _inherit = 'nh.clinical.patient.observation.pain'
 
-    @refresh_materialized_views('param')
+    @v7_materialized_queue('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_pain, self).complete(
@@ -67,7 +67,7 @@ class nh_clinical_patient_observation_pain(orm.Model):
 class nh_clinical_patient_observation_urine_output(orm.Model):
     _inherit = 'nh.clinical.patient.observation.urine_output'
 
-    @refresh_materialized_views('param')
+    @v7_materialized_queue('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_urine_output, self).complete(
@@ -77,7 +77,7 @@ class nh_clinical_patient_observation_urine_output(orm.Model):
 class nh_clinical_patient_observation_bowels_open(orm.Model):
     _inherit = 'nh.clinical.patient.observation.bowels_open'
 
-    @refresh_materialized_views('param')
+    @v7_materialized_queue('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_observation_bowels_open, self).complete(
@@ -87,7 +87,7 @@ class nh_clinical_patient_observation_bowels_open(orm.Model):
 class nh_clinical_patient_mrsa(orm.Model):
     _inherit = 'nh.clinical.patient.mrsa'
 
-    @refresh_materialized_views('param')
+    @v7_materialized_queue('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_mrsa, self).complete(
@@ -97,7 +97,7 @@ class nh_clinical_patient_mrsa(orm.Model):
 class nh_clinical_patient_diabetes(orm.Model):
     _inherit = 'nh.clinical.patient.diabetes'
 
-    @refresh_materialized_views('param')
+    @v7_materialized_queue('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_diabetes, self).complete(
@@ -107,7 +107,7 @@ class nh_clinical_patient_diabetes(orm.Model):
 class nh_clinical_patient_palliative_care(orm.Model):
     _inherit = 'nh.clinical.patient.palliative_care'
 
-    @refresh_materialized_views('param')
+    @v7_materialized_queue('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_palliative_care, self).complete(
@@ -117,7 +117,7 @@ class nh_clinical_patient_palliative_care(orm.Model):
 class nh_clinical_patient_post_surgery(orm.Model):
     _inherit = 'nh.clinical.patient.post_surgery'
 
-    @refresh_materialized_views('param')
+    @v7_materialized_queue('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_post_surgery, self).complete(
@@ -127,7 +127,7 @@ class nh_clinical_patient_post_surgery(orm.Model):
 class nh_clinical_patient_critical_care(orm.Model):
     _inherit = 'nh.clinical.patient.critical_care'
 
-    @refresh_materialized_views('param')
+    @v7_materialized_queue('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_critical_care, self).complete(
@@ -137,7 +137,7 @@ class nh_clinical_patient_critical_care(orm.Model):
 class nh_clinical_patient_urine_output_target(orm.Model):
     _inherit = 'nh.clinical.patient.uotarget'
 
-    @refresh_materialized_views('param')
+    @v7_materialized_queue('param')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_urine_output_target, self).complete(
@@ -147,7 +147,7 @@ class nh_clinical_patient_urine_output_target(orm.Model):
 class nh_clinical_patient_pbp_monitoring(orm.Model):
     _inherit = 'nh.clinical.patient.pbp_monitoring'
 
-    @refresh_materialized_views('pbp')
+    @v7_materialized_queue('pbp')
     def complete(self, cr, uid, activity_id, context=None):
         return super(
             nh_clinical_patient_pbp_monitoring, self).complete(

--- a/nh_eobs/security/ir.model.access.csv
+++ b/nh_eobs/security/ir.model.access.csv
@@ -101,3 +101,5 @@ doctor_access_monitoring_exception_reason,doctor:access_monitoring_exception_rea
 ,,,,,,,
 access_nh_clinical_settings,access_nh_clinical_settings,model_nh_clinical_settings,,1,1,1,1
 access_nh_clinical_settings_workload,access_nh_clinical_settings_workload,model_nh_clinical_settings_workload,,1,1,1,1
+,,,,,,,
+access_materialized_queue,"Access NH Clinical Materialized Queue",model_nh_clinical_materialized_queue,,1,1,1,0

--- a/nh_eobs/sql_statements.py
+++ b/nh_eobs/sql_statements.py
@@ -135,21 +135,13 @@ class NHEobsSQL(orm.AbstractModel):
             AS clinical_risk,
         ews1.score - ews2.score AS ews_trend,
         param.height,
-        param.o2target_level_id AS o2target,
+        NULL AS o2target,
         CASE WHEN param.mrsa THEN 'yes' ELSE 'no' END AS mrsa,
         CASE WHEN param.diabetes THEN 'yes' ELSE 'no' END AS diabetes,
         CASE WHEN pbp.status THEN 'yes' ELSE 'no' END AS pbp_monitoring,
         CASE WHEN param.status THEN 'yes' ELSE 'no' END AS palliative_care,
-        CASE
-            WHEN param.post_surgery AND param.post_surgery_date > now() -
-                INTERVAL '4h' THEN 'yes'
-            ELSE 'no'
-        END AS post_surgery,
-        CASE
-            WHEN param.critical_care AND param.critical_care_date > now() -
-                INTERVAL '24h' THEN 'yes'
-            ELSE 'no'
-        END AS critical_care,
+        'no' AS post_surgery,
+        'no' AS critical_care,
         param.uotarget_vol,
         param.uotarget_unit,
         consulting_doctors.names AS consultant_names,

--- a/nh_eobs/wardboard.py
+++ b/nh_eobs/wardboard.py
@@ -1411,37 +1411,20 @@ param as(
         select
             activity.spell_id,
             height.height,
-            diabetes.status as diabetes,
-            mrsa.status as mrsa,
-            pc.status,
-            o2target_level.id as o2target_level_id,
-            ps.status as post_surgery,
-            psactivity.date_terminated as post_surgery_date,
-            cc.status as critical_care,
-            ccactivity.date_terminated as critical_care_date,
+            false as diabetes,
+            false as mrsa,
+            false as status,
+            false as post_surgery,
+            null as post_surgery_date,
+            false as critical_care,
+            null as critical_care_date,
             uotarget.volume as uotarget_vol,
             uotarget.unit as uotarget_unit
         from wb_activity_latest activity
         left join nh_clinical_patient_observation_height height
             on activity.ids && array[height.activity_id]
-        left join nh_clinical_patient_diabetes diabetes
-            on activity.ids && array[diabetes.activity_id]
-        left join nh_clinical_patient_o2target o2target
-            on activity.ids && array[o2target.activity_id]
-        left join nh_clinical_o2level o2target_level
-            on o2target_level.id = o2target.level_id
-        left join nh_clinical_patient_mrsa mrsa
-            on activity.ids && array[mrsa.activity_id]
-        left join nh_clinical_patient_palliative_care pc
-            on activity.ids && array[pc.activity_id]
-        left join nh_clinical_patient_post_surgery ps
-            on activity.ids && array[ps.activity_id]
         left join nh_clinical_patient_uotarget uotarget
             on activity.ids && array[uotarget.activity_id]
-        left join nh_activity psactivity on psactivity.id = ps.activity_id
-        left join nh_clinical_patient_critical_care cc
-            on activity.ids && array[cc.activity_id]
-        left join nh_activity ccactivity on ccactivity.id = cc.activity_id
         where activity.state = 'completed'
 );
 

--- a/nh_eobs_mental_health/models/nh_clinical_wardboard.py
+++ b/nh_eobs_mental_health/models/nh_clinical_wardboard.py
@@ -121,6 +121,7 @@ class NHClinicalWardboard(orm.Model):
             'view_id': view_id
         }
 
+    @helpers.v8_refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
     @api.multi
     def start_obs_stop(self, reasons, spell_id, spell_activity_id):
         """
@@ -164,6 +165,7 @@ class NHClinicalWardboard(orm.Model):
         obs_stop = activity.data_ref
         obs_stop.start(activity_id)
 
+    @helpers.v8_refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
     @api.multi
     def end_obs_stop(self, cancellation=False):
         """

--- a/nh_eobs_mental_health/models/nh_clinical_wardboard.py
+++ b/nh_eobs_mental_health/models/nh_clinical_wardboard.py
@@ -121,7 +121,7 @@ class NHClinicalWardboard(orm.Model):
             'view_id': view_id
         }
 
-    @helpers.v8_refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
+    @helpers.v8_materialized_queue('ews0', 'ews1', 'ews2', 'bg0')
     @api.multi
     def start_obs_stop(self, reasons, spell_id, spell_activity_id):
         """
@@ -165,7 +165,7 @@ class NHClinicalWardboard(orm.Model):
         obs_stop = activity.data_ref
         obs_stop.start(activity_id)
 
-    @helpers.v8_refresh_materialized_views('ews0', 'ews1', 'ews2', 'bg0')
+    @helpers.v8_materialized_queue('ews0', 'ews1', 'ews2', 'bg0')
     @api.multi
     def end_obs_stop(self, cancellation=False):
         """

--- a/nh_eobs_mobile/controllers/main.py
+++ b/nh_eobs_mobile/controllers/main.py
@@ -766,6 +766,11 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
                 self._cancel_next_blood_glucose(cr, uid, obj_nh_activity, activity,
                                                 context)
 
+            cr.execute(
+                'refresh materialized view ews0;\n'
+                'refresh materialized view bg0;'
+            )
+
         if tasks:
             self._check_custom_frequency(tasks[0])
         return self.get_tasks()
@@ -786,6 +791,7 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
             next_ews_activity = obj_nh_activity.browse(cr, uid, next_ews_activity_id, context=context)
             next_ews_activity.data_ref.write(
                 {'frequency': spell.custom_frequency})
+            request.cr.execute("""refresh materialized view ews0;""")
 
     @staticmethod
     def _cancel_next_blood_glucose(cr, uid, obj_nh_activity, activity, context):
@@ -806,6 +812,7 @@ class MobileFrontend(openerp.addons.web.controllers.main.Home):
             ('patient_id', '=', activity.patient_id.id)
         ], context=context)
         obj_nh_activity.cancel(cr, uid, next_blood_glucose_activity_id, context=context)
+        cr.execute("""refresh materialized view bg0;""")
 
     @http.route(URLS['share_patient_list'], type='http', auth='user')
     def get_share_patients(self, *args, **kw):


### PR DESCRIPTION
When under load, PSQL deadlocks occur because of the number of 'refresh materialized view X' that are being called. This commit changes the direct call to instead add the views that need to be refreshed to a queue. This queue will then get processed by a parallel container.