### PR TITLE
[FIX] TypeError when stopping observations

### DIFF
--- a/nh_eobs/models/nh_clinical_patient_monitoring_exception.py
+++ b/nh_eobs/models/nh_clinical_patient_monitoring_exception.py
@@ -33,6 +33,7 @@ class PatientMonitoringException(models.Model):
     def complete(self, activity_id):
         return super(PatientMonitoringException, self).complete(activity_id)
 
+    @api.model
     def cancel(self, activity_id):
         return super(PatientMonitoringException, self).cancel(activity_id)
 


### PR DESCRIPTION
New API method called without api decorator results with a '..takes exactly 2 arguments (4 given)' error

Fixes #17589