### PR TITLE
[FIX] Singleton error when transferring a patient after an admission …

### DIFF
--- a/nh_eobs/api.py
+++ b/nh_eobs/api.py
@@ -1010,7 +1010,7 @@ class nh_eobs_api(orm.AbstractModel):
         spell = spell_model.search(
             [
                 ('patient_id', '=', patient.id),
-                ('activity_id.state', '!=', 'completed')
+                ('activity_id.state', 'not in', ['completed', 'cancelled'])
             ]
         )
         # There may be no open spells, so the ensure_one is disabled for now


### PR DESCRIPTION
…is cancelled

Given the following process, a singleton error occurs. It is related to a method that exists on nh.eobs.api that is only called by the 'Food and Fluid' module. Method should only return either a spell that is in 'started' state, or no spell at all.

(A01) Admit Patient
(A11) Cancel Patient Admission
(A01) Admin (the same) Patient
(A02) Transfer patient

Fixes #17960